### PR TITLE
fix: catalog.json has incorrect types

### DIFF
--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -414,7 +414,7 @@
 						{
 							"key": "management_endpoint_type_for_bucket",
 							"description": "The type of endpoint for the IBM terraform provider to use to manage the bucket. (public, private, or direct)",
-							"type": "boolean",
+							"type": "string",
 							"hidden": true,
 							"default_value": "private",
 							"options": [
@@ -541,7 +541,7 @@
 						{
 							"key": "kms_endpoint_type",
 							"description": "The type of endpoint to be used for management of key protect.",
-							"type": "boolean",
+							"type": "string",
 							"hidden": true,
 							"default_value": "private",
 							"options": [


### PR DESCRIPTION
### Description

types in the catalog.json introduced an error:

```json
{
    "errors": [
        {
            "statusCode": 500,
            "error": "Internal Server Error",
            "message": "Missing parameter on request",
            "description": "Missing parameter on request",
            "errorCode": "GRAMPS_ERROR",
            "graphqlModel": null,
            "locations": [
                {
                    "line": 1,
                    "column": 7
                }
            ],
            "path": null,
            "guid": "e5277ec8-33da-4511-abe5-80186b186818"
        }
    ]
}
```

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

fix the types in the catalog.json

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
